### PR TITLE
feat(docker): make v8 flavour of image

### DIFF
--- a/Dockerfile-8
+++ b/Dockerfile-8
@@ -1,0 +1,15 @@
+FROM node:8-alpine
+LABEL name="build-essential-8"
+LABEL description="Node Build Essential Docker Image (Node v8)"
+LABEL maintainer="Ahmad Nassri <ahmad.nassri@telus.com>"
+
+RUN apk add --update --no-cache ca-certificates git openssh
+
+USER node
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:$NPM_CONFIG_PREFIX/bin
+ENV MANPATH=$MANPATH:$NPM_CONFIG_PREFIX/share/man
+ENV NODE_PATH=$NPM_CONFIG_PREFIX/lib/node_modules
+
+RUN npx install-peerdeps --only-peers --global @telus/build-essential

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@telus/build-essential",
-  "version": "1.6.0",
+  "version": "0.0.0-development",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "npx run-p lint:*"
   },
   "peerDependencies": {
-    "@telus/eslint-config": "^1.3.4",
+    "@telus/eslint-config": "^1.3.5",
     "@telus/remark-preset-lint-markdown": "^1.1.0",
     "@telus/semantic-release-config": "^1.0.4",
     "editorconfig-checker": "^1.3.3",


### PR DESCRIPTION
For use by TDS, who require a verison of Node <= 9.