### PR TITLE
fix(md lint): change 'remark' to 'remark-cli'

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:audit": "npm audit",
     "lint:deps": "npx updated",
     "lint:ec": "npx editorconfig-checker .",
-    "lint:md": "npx remark --quiet --frail .",
+    "lint:md": "npx remark-cli --quiet --frail .",
     "lint": "npx npm-run-all -p -c -l lint:*",
     "fix:md": "npm run lint:md -- -o",
     "fix:deps": "npm run lint:deps -- --update",


### PR DESCRIPTION
We install `remark-cli` for markdown linting, but the `lint:md` npm script references the `remark` package.

Changing the `lint:md` script to use `remark-cli` fixes the issue.